### PR TITLE
fix: Remove Github maven publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,11 +28,6 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build
 
-      - name: Publish to GitHub Packages
-        run: ./gradlew publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Publish to JFrog Artifactory
         run: ./gradlew artifactoryPublish
         env:

--- a/build.gradle
+++ b/build.gradle
@@ -129,17 +129,6 @@ publishing {
         }
     }
 
-    repositories {
-        maven {
-            name = "GitHubPackages"
-            url = "https://maven.pkg.github.com/hyperledger/besu-errorprone-checks"
-            credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
-            }
-        }
-    }
-
     def artifactoryUser = project.hasProperty('artifactoryUser') ? project.property('artifactoryUser') : System.getenv('ARTIFACTORY_USER')
     def artifactoryKey = project.hasProperty('artifactoryApiKey') ? project.property('artifactoryApiKey') : System.getenv('ARTIFACTORY_KEY')
     def artifactoryRepo = System.getenv('ARTIFACTORY_REPO') ?: 'besu-maven'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.1.2
+version=0.1.3
 
 org.gradle.welcome=never
 


### PR DESCRIPTION
Remove Github maven publishing in favor of Artifactory. To test the CI publishing, change the library version to 0.1.3